### PR TITLE
CTV-3608 | Update reference apps to use evergreen ads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## v1.3.0
+* Updated preroll and midroll ads to Evergreen ads.
+
 ## v1.0.0
 * Initial implementation for Roku facing demonstration channel, featuring stitched-in true[X] choice card flows.

--- a/manifest
+++ b/manifest
@@ -3,8 +3,8 @@
 ##   Channel Details
 title=TAR-Roku-Reference
 major_version=1
-minor_version=2
-build_version=0002
+minor_version=3
+build_version=0000
 ui_resolutions=fhd
 supports_input_launch=1
 rsg_version=1.2

--- a/res/adpod/truex-pod-midroll.xml
+++ b/res/adpod/truex-pod-midroll.xml
@@ -5,7 +5,7 @@
             <AdSystem>trueX</AdSystem>
             <AdTitle>true[X] Interactive Ad</AdTitle>
             <Description>Interactive ad from true[X]</Description>
-            <VASTAdTagURI><![CDATA[http://get.truex.com/f10e25d796a25c294dc308f2b5f916cdd3d670e9/vast?dimension_2=1&dimension_5=evergreen&stream_position=midroll&network_user_id=ROKU_ADS_TRACKING_ID]]></VASTAdTagURI>
+            <VASTAdTagURI><![CDATA[http://get.truex.com/74fca63c733f098340b0a70489035d683024440d/vast?dimension_2=1&dimension_5=evergreen&stream_position=midroll&network_user_id=ROKU_ADS_TRACKING_ID]]></VASTAdTagURI>
             <Impression></Impression>
             <Creatives></Creatives>
         </Wrapper>

--- a/res/adpod/truex-pod-preroll.xml
+++ b/res/adpod/truex-pod-preroll.xml
@@ -5,7 +5,7 @@
             <AdSystem>trueX</AdSystem>
             <AdTitle>true[X] Interactive Ad</AdTitle>
             <Description>Interactive ad from true[X]</Description>
-            <VASTAdTagURI><![CDATA[http://get.truex.com/f10e25d796a25c294dc308f2b5f916cdd3d670e9/vast?dimension_2=0&dimension_5=evergreen&stream_position=preroll&network_user_id=ROKU_ADS_TRACKING_ID]]></VASTAdTagURI>
+            <VASTAdTagURI><![CDATA[http://get.truex.com/74fca63c733f098340b0a70489035d683024440d/vast?dimension_2=0&dimension_5=evergreen&stream_position=preroll&network_user_id=ROKU_ADS_TRACKING_ID]]></VASTAdTagURI>
             <Impression></Impression>
             <Creatives></Creatives>
         </Wrapper>


### PR DESCRIPTION
* Updated VASTAdTagURI in truex-pod-preroll and truex-pod-midroll.xml for valid evergreen ads